### PR TITLE
New parameter package_ensure

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,7 +9,7 @@ class ipset::install {
 
   # main package
   package { $::ipset::params::package:
-    ensure => 'latest',
+    ensure => $::ipset::params::package_ensure,
     alias  => 'ipset',
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,8 +2,11 @@
 #
 # @param use_firewall_service Define the firewall service used by the server.
 #   Defaults to the Linux distribution default.
+# @param package_ensure Defines the package ensure status of the ipset package.
+#   Defaults to latest.
 class ipset::params (
   Optional[Enum['iptables', 'firewalld']] $use_firewall_service = undef,
+  Enum['latest','present'] $package_ensure = 'latest',
 ) {
   $package = $facts['os']['family'] ? {
     'RedHat' => 'ipset',

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -98,6 +98,7 @@ def check_rhel7_systemd_unit(firewall_service)
 end
 # rubocop:enable  Metrics/MethodLength
 
+# rubocop:disable  Metrics/BlockLength
 describe 'ipset::install' do
   %w[iptables firewalld].each do |firewall_service|
     context "RedHat 7 - #{firewall_service}" do
@@ -122,4 +123,19 @@ describe 'ipset::install' do
       end
     end
   end
+  context 'with package_ensure set' do
+    let(:pre_condition) do
+      <<~CONDITION
+        class { '::ipset::params':
+          package_ensure => 'present',
+        }
+      CONDITION
+    end
+    it do
+      is_expected.to contain_package('ipset').with(
+        ensure: 'present'
+      )
+    end
+  end
 end
+# rubocop:enable  Metrics/BlockLength


### PR DESCRIPTION
`package_ensure` defaults to the current `latest` value
and can be configured as `latest` or `present` to specify
how the ensure is specified on the package `ipsets`.