### PR TITLE
Remove thrnio/ip dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,4 @@ fixtures:
   forge_modules:
     stdlib:
       repo: 'puppetlabs/stdlib'
-      ref: '4.24.0'
-    ip:
-      repo: 'thrnio/ip'
-      ref: '1.0.1'
+      ref: '4.25.0'

--- a/metadata.json
+++ b/metadata.json
@@ -40,11 +40,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.24.0 <5.0.0"
-    },
-    {
-      "name": "thrnio/ip",
-      "version_requirement": ">=1.0.0 <2.0.0"
+      "version_requirement": ">=4.25.0 <5.0.0"
     }
   ]
 }


### PR DESCRIPTION
This module has been deprecated and is no longer maintained. Its functionality has been incorporated in puppetlabs/stdlib v4.25.0.

See : https://github.com/thrnio/puppet-ip#deprecated