### PR TITLE
Add rest of hash types, add support for inline comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,5 @@ matrix:
       env: CHECK=spec
     -
       env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
-    -
-      env: CHECK=build DEPLOY_TO_FORGE=yes
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,18 @@ matrix:
       env: CHECK=spec
     -
       env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
+    -
+      env: CHECK=build DEPLOY_TO_FORGE=yes
 notifications:
   email: false
+deploy:
+  provider: puppetforge
+  edge:
+    branch: puppet_forge-post-1_9_0
+  user: pmuller
+  password:
+    secure: "YS6qRI1o+zkmvygv69yLwXxh+VVi/4Kpk0sUr4IqJIDPyQfkwyvNv2oUBkkRnzSseYuI2+PF9g65ug0g6AVaqCvOGqXL5EFgOU1YutmEJfugp/Sv8NEZ50NpMKHv1bjmxEmM30Z8eQIOZ5Hv1u36DBhcAa6s2mm4V39+XMW4o8aDY/cNKQkdrwssHVjuzogHzd3+XFSglHxH/IwsmdbddQZpwDoQiPvLRAKILn8oo8t/teZQg4tHSLBx8dIkh+vIQ3grH5UHQ/hT8spH28A3C8CoLABhEfDTkAPizn4E7ngTuLbaTv4AdtQ15WqA//wJiwBl71uVbwG6l0skamrxcPaGsJhAAKix/yE0gyop4BnEwt33Jhfe4vrgUEqxIct/ktbTn0Dl+l4t2qczkYPEr4VEBJ6nBdozLOsK/u+2fgZJlymk3sx4kA9MFe5J32b3MmDN5VjlD3LqkOlSMBpWucVVqPJiowGjnbfJnv55v4dPciKq59fBPsJs7Rzcz0whYUg6JZS8wMEH7KJ/gpu4JRXC7hR4jm01qitTVa+htX4zfYkwV6yQ/ahBwz//peQpqc2WYda6mFgWTtx3aKi3gs9/7auIzgcytoWsHi+eMPo4lgHsOAaMHaDSsjpQpSHdn6RzELV2AeaFoEKqXacrwMrJXbGuiuGn+xrfbi1Sgw4="
+  on:
+    tags: true
+    all_branches: true
+    condition: "$DEPLOY_TO_FORGE = yes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,14 +33,3 @@ matrix:
       env: CHECK=build DEPLOY_TO_FORGE=yes
 notifications:
   email: false
-deploy:
-  provider: puppetforge
-  edge:
-    branch: puppet_forge-post-1_9_0
-  user: pmuller
-  password:
-    secure: "YS6qRI1o+zkmvygv69yLwXxh+VVi/4Kpk0sUr4IqJIDPyQfkwyvNv2oUBkkRnzSseYuI2+PF9g65ug0g6AVaqCvOGqXL5EFgOU1YutmEJfugp/Sv8NEZ50NpMKHv1bjmxEmM30Z8eQIOZ5Hv1u36DBhcAa6s2mm4V39+XMW4o8aDY/cNKQkdrwssHVjuzogHzd3+XFSglHxH/IwsmdbddQZpwDoQiPvLRAKILn8oo8t/teZQg4tHSLBx8dIkh+vIQ3grH5UHQ/hT8spH28A3C8CoLABhEfDTkAPizn4E7ngTuLbaTv4AdtQ15WqA//wJiwBl71uVbwG6l0skamrxcPaGsJhAAKix/yE0gyop4BnEwt33Jhfe4vrgUEqxIct/ktbTn0Dl+l4t2qczkYPEr4VEBJ6nBdozLOsK/u+2fgZJlymk3sx4kA9MFe5J32b3MmDN5VjlD3LqkOlSMBpWucVVqPJiowGjnbfJnv55v4dPciKq59fBPsJs7Rzcz0whYUg6JZS8wMEH7KJ/gpu4JRXC7hR4jm01qitTVa+htX4zfYkwV6yQ/ahBwz//peQpqc2WYda6mFgWTtx3aKi3gs9/7auIzgcytoWsHi+eMPo4lgHsOAaMHaDSsjpQpSHdn6RzELV2AeaFoEKqXacrwMrJXbGuiuGn+xrfbi1Sgw4="
-  on:
-    tags: true
-    all_branches: true
-    condition: "$DEPLOY_TO_FORGE = yes"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ ipset { 'foo':
 
 You can also pass a pre-formatted string directly, using one entry per line
 (with ``\n`` as a separator).
+Inline comments are supported starting with `#`.
 This pattern is practical when generating the IP set entries using a template.
 
 ```puppet
@@ -89,6 +90,7 @@ file { '/tmp/bar_set_content':
 
 * Only tested on RedHat-like Linux distributions
 * IPv6 sets have not been tested yet
+* Only *hash* ipsets are supported (this excludes bitmaps and list:set)
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Puppet Forge](http://img.shields.io/puppetforge/v/pmuller/ipset.svg)](https://forge.puppetlabs.com/pmuller/ipset)
 [![Puppet Forge downloads](https://img.shields.io/puppetforge/dt/pmuller/ipset.svg)](https://forge.puppetlabs.com/pmuller/ipset)
-[![Build Status](https://travis-ci.org/pmuller/puppet-ipset.svg)](https://travis-ci.org/pmuller/puppet-ipset)
+[![Build Status](https://travis-ci.org/pmuller/puppet-ipset.svg)](https://travis-ci.org/tuenti/puppet-ipset)
 
 #### Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ file { '/tmp/bar_set_content':
 
 * Only tested on RedHat-like Linux distributions
 * IPv6 sets have not been tested yet
-* Only *hash* ipsets are supported (this excludes bitmaps and list:set)
+* Only **hash** ipsets are supported (this excludes *bitmap* and *list:set*)
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Puppet Forge](http://img.shields.io/puppetforge/v/pmuller/ipset.svg)](https://forge.puppetlabs.com/pmuller/ipset)
 [![Puppet Forge downloads](https://img.shields.io/puppetforge/dt/pmuller/ipset.svg)](https://forge.puppetlabs.com/pmuller/ipset)
-[![Build Status](https://travis-ci.org/pmuller/puppet-ipset.svg)](https://travis-ci.org/tuenti/puppet-ipset)
+[![Build Status](https://travis-ci.org/pmuller/puppet-ipset.svg)](https://travis-ci.org/pmuller/puppet-ipset)
 
 #### Table of Contents
 

--- a/files/ipset_sync
+++ b/files/ipset_sync
@@ -70,7 +70,7 @@ function construct_ipset_dump() {
         sed -re 's@^[[:space:]]*@@' | \
         sed -re 's@[[:space:]]*$@@' | \
         sed -re 's@/((32)|(128))$@@' | \
-        sed -re 's@[[:space:]]*#*.*$@@' | \
+        sed -re 's@[[:space:]]*#.*$@@' | \
         sed -re "s/(.*)/add ${alias} \\1/" | \
         LC_ALL=C sort --unique
     fi

--- a/files/ipset_sync
+++ b/files/ipset_sync
@@ -70,6 +70,7 @@ function construct_ipset_dump() {
         sed -re 's@^[[:space:]]*@@' | \
         sed -re 's@[[:space:]]*$@@' | \
         sed -re 's@/((32)|(128))$@@' | \
+        sed -re 's@[[:space:]]#*$@@' | \
         sed -re "s/(.*)/add ${alias} \\1/" | \
         LC_ALL=C sort --unique
     fi

--- a/files/ipset_sync
+++ b/files/ipset_sync
@@ -63,6 +63,7 @@ function construct_ipset_dump() {
       #   * empty lines
       # * cleanup
       #   * network mask suffix in complete IP (IPv4=32, IPv6=128)
+      #   * remove inline comments
       #   * trim whitespaces
       cat "${f_content}" | \
         grep -v '^[[:space:]]*#' | \

--- a/files/ipset_sync
+++ b/files/ipset_sync
@@ -70,7 +70,7 @@ function construct_ipset_dump() {
         sed -re 's@^[[:space:]]*@@' | \
         sed -re 's@[[:space:]]*$@@' | \
         sed -re 's@/((32)|(128))$@@' | \
-        sed -re 's@[[:space:]]#*$@@' | \
+        sed -re 's@[[:space:]]*#*.*$@@' | \
         sed -re "s/(.*)/add ${alias} \\1/" | \
         LC_ALL=C sort --unique
     fi

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -77,7 +77,7 @@ simple_test_cases = [
     'string',
     ["10.0.0.1,80\n192.168.0.1,443"],
     { content: "10.0.0.1,80\n192.168.0.1,443" }
-  ],
+  ]
 ]
 
 describe 'ipset' do

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -57,7 +57,27 @@ simple_test_cases = [
     'file url',
     'file:///foo/bar',
     { source: '/foo/bar' }
-  ]
+  ],
+  [
+    'array',
+    ['10.0.0.1 #Comment 1', '192.168.0.1 #Comment 2'],
+    { content: "10.0.0.1\n192.168.0.1" }
+  ],
+  [
+    'array',
+    ['10.0.0.1,80', '192.168.0.1,443'],
+    { content: "10.0.0.1,80\n192.168.0.1,443" }
+  ],
+  [
+    'string',
+    ["10.0.0.1 #Comment 1\n192.168.0.1 #Comment 2"],
+    { content: "10.0.0.1\n192.168.0.1" }
+  ],
+  [
+    'string',
+    ["10.0.0.1,80\n192.168.0.1,443"],
+    { content: "10.0.0.1,80\n192.168.0.1,443" }
+  ],
 ]
 
 describe 'ipset' do

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -61,7 +61,7 @@ simple_test_cases = [
   [
     'array',
     ['10.0.0.1 #Comment 1', '192.168.0.1 #Comment 2'],
-    { content: "10.0.0.1\n192.168.0.1" }
+    { content: "10.0.0.1 #Comment 1\n192.168.0.1 #Comment 2" }
   ],
   [
     'array',
@@ -71,7 +71,7 @@ simple_test_cases = [
   [
     'string',
     ["10.0.0.1 #Comment 1\n192.168.0.1 #Comment 2"],
-    { content: "10.0.0.1\n192.168.0.1" }
+    { content: "10.0.0.1 #Comment 1\n192.168.0.1 #Comment 2" }
   ],
   [
     'string',

--- a/types/type.pp
+++ b/types/type.pp
@@ -1,4 +1,13 @@
 type IPSet::Type = Enum[
   'hash:ip',
+  'hash:ip,port',
+  'hash:ip,port,ip',
+  'hash:ip,port,net',
+  'hash:ip,mark',
   'hash:net',
+  'hash:net,net',
+  'hash:net,iface',
+  'hash:net,port',
+  'hash:net,port,net',
+  'hash:mac',
 ]


### PR DESCRIPTION
The goal of this PR is:
- Add support for all of the current ipset hash types.
- Add support for inline comments in `*.set` files