### PR TITLE
Be selective about striping /32 or /128 from network

### DIFF
--- a/files/ipset_sync
+++ b/files/ipset_sync
@@ -25,6 +25,7 @@ Options:
   -v  Verbose output
   -h  Shows this help message
   -i  Name of managed ipset
+  -f  family inet||inet6
 EOF
 }
 
@@ -64,12 +65,17 @@ function construct_ipset_dump() {
       # * cleanup
       #   * network mask suffix in complete IP (IPv4=32, IPv6=128)
       #   * trim whitespaces
+      if [ $family == 'inet' ] ; then
+          $suffix=32
+      else
+          $suffix=128
+      fi
       cat "${f_content}" | \
         grep -v '^[[:space:]]*#' | \
         grep -v '^[[:space:]]*$' | \
         sed -re 's@^[[:space:]]*@@' | \
         sed -re 's@[[:space:]]*$@@' | \
-        sed -re 's@/((32)|(128))$@@' | \
+        sed -re "s/\/${suffix}$//" | \
         sed -re "s/(.*)/add ${alias} \\1/" | \
         LC_ALL=C sort --unique
     fi
@@ -139,14 +145,18 @@ set_id=''
 check_only=0
 ignore_contents=0
 cfg="${default_cfg}"
+family='inet'
 
-while getopts "vc:dhi:n" OPTION; do
+while getopts "vc:dhi:nf:" OPTION; do
     case ${OPTION} in
       c)
         cfg=${OPTARG}
         ;;
       d)
         check_only=1
+        ;;
+      f)
+        family=${OPTARG}
         ;;
       h)
         usage

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,11 @@ define ipset (
   # keep definition file and in-kernel runtime state in sync
   Boolean $keep_in_sync = true,
 ) {
+
+  if versioncmp($facts['os']['release']['major'],'8') >= 0 {
+    fail('The ipset module is not supported on C8 and newer. Use firewalld_ipset type from puppet-firewalld module on 8 and newer')
+  }
+
   include ipset::params
 
   contain ipset::install
@@ -111,10 +116,10 @@ define ipset (
       path    => [ '/sbin', '/usr/sbin', '/bin', '/usr/bin' ],
 
       # use helper script to do the sync
-      command => "/usr/local/sbin/ipset_sync -c '${::ipset::params::config_path}'    -i ${title}${ignore_contents_opt}",
+      command => "/usr/local/sbin/ipset_sync -f ${actual_options['family']} -c '${::ipset::params::config_path}'    -i ${title}${ignore_contents_opt}",
 
       # only when difference with in-kernel set is detected
-      unless  => "/usr/local/sbin/ipset_sync -c '${::ipset::params::config_path}' -d -i ${title}${ignore_contents_opt}",
+      unless  => "/usr/local/sbin/ipset_sync -f ${actual_options['family']} -c '${::ipset::params::config_path}' -d -i ${title}${ignore_contents_opt}",
 
       require => Package['ipset'],
     }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -76,8 +76,8 @@ describe 'ipset' do
       check_exec_sync(
         'simple',
         # rubocop:disable Metrics/LineLength
-        command: "/usr/local/sbin/ipset_sync -c '/etc/sysconfig/ipset.d'    -i simple",
-        unless: "/usr/local/sbin/ipset_sync -c '/etc/sysconfig/ipset.d' -d -i simple",
+        command: "/usr/local/sbin/ipset_sync -f inet -c '/etc/sysconfig/ipset.d'    -i simple",
+        unless: "/usr/local/sbin/ipset_sync -f inet -c '/etc/sysconfig/ipset.d' -d -i simple",
         # rubocop:enable Metrics/LineLength
       )
     end
@@ -106,8 +106,8 @@ describe 'ipset' do
     check_exec_sync(
       'custom',
       # rubocop:disable Metrics/LineLength
-      command: "/usr/local/sbin/ipset_sync -c '/etc/sysconfig/ipset.d'    -i custom -n",
-      unless: "/usr/local/sbin/ipset_sync -c '/etc/sysconfig/ipset.d' -d -i custom -n",
+      command: "/usr/local/sbin/ipset_sync -f inet -c '/etc/sysconfig/ipset.d'    -i custom -n",
+      unless: "/usr/local/sbin/ipset_sync -f inet -c '/etc/sysconfig/ipset.d' -d -i custom -n",
       # rubocop:enable Metrics/LineLength
     )
   end


### PR DESCRIPTION
For clean up /32 or /128 was being stripped from networks before
being entered into ipsets. In particular.

2001:1458::/32 was being stripped to 2001:1458::
which is of course incorrect